### PR TITLE
ci: Add --ignore-scripts flag to npm install commands

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm install --ignore-scripts
 
       - name: Run tests
         run: npm test


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` flag to npm ci/install commands in CI workflows

## Rationale
This prevents npm from executing any lifecycle scripts (including postinstall) during dependency installation, reducing the attack surface from malicious packages.

## Test plan
- [ ] CI workflows still pass
- [ ] Dependencies are installed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)